### PR TITLE
Fix: Tooltip text

### DIFF
--- a/src/main/java/uk/co/hexeption/apec/hud/elements/ToolTipText.java
+++ b/src/main/java/uk/co/hexeption/apec/hud/elements/ToolTipText.java
@@ -55,20 +55,13 @@ public class ToolTipText extends Element {
     }
 
     public int getXOffset(GuiGraphics guiGraphics) {
-        var deltaH = itemHotBar.getDeltaPosition();
-        var scaleH = itemHotBar.getScale();
 
-        var x = guiGraphics.guiWidth() + deltaH.x / scaleH - 185;
-        return (int) x;
+        return (int) getCurrentAnchorPoint().x;
     }
 
     public int getYOffset(GuiGraphics guiGraphics) {
 
-        var deltaH = itemHotBar.getDeltaPosition();
-        var scaleH = itemHotBar.getScale();
-
-        var y = guiGraphics.guiHeight() + deltaH.y / scaleH - 56;
-        return (int) y;
+        return (int) getCurrentAnchorPoint().y;
     }
 
 }

--- a/src/main/java/uk/co/hexeption/apec/mixins/MixinGui.java
+++ b/src/main/java/uk/co/hexeption/apec/mixins/MixinGui.java
@@ -249,6 +249,11 @@ public abstract class MixinGui implements MC {
             return original;
         }
 
+        if(Apec.INSTANCE.settingsManager.getSettingState(SettingID.ITEM_HIGHLIGHT_TEXT)){
+            int textWidth = guiGraphics.guiWidth() - 2 * original;
+            return toolTipText.getXOffset(guiGraphics) + (mc.font.width("hello") - textWidth) / 2;
+        }
+
         return toolTipText.getXOffset(guiGraphics);
     }
 


### PR DESCRIPTION
Having my held item's tooltip be in my health bar was annoying so I figured i'd fix it :/

- Fixed tooltip text not updating its position after editing
- Fixed the 'normal tooltip' setting not centering the tooltip text.