### PR TITLE
fix + feature: Element Scaling and Tooltip Position

### DIFF
--- a/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationScaleWidget.java
+++ b/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationScaleWidget.java
@@ -52,23 +52,23 @@ public class CustomizationScaleWidget extends Button implements MC {
 
 
     @Override
-    public boolean mouseDragged(/*? if > 1.21.8 {*/MouseButtonEvent event, double mouseX, double mouseY/*?} else {*//*double d, double e, int i, double f, double g*//*?}*/) {
+    public boolean mouseDragged(MouseButtonEvent event, double mouseX, double mouseY) {
         if(isUserDragging){
             Vector2f realAnchor = this.element.getCurrentAnchorPoint();
             Vector2f boundingPoint = this.element.getCurrentBoundingPoint();
-            int differenceX = (int) ((/*? if > 1.21.8 {*/event.x()/*?} else {*//*d*//*?}*/ - this.initialX) * (realAnchor.x < boundingPoint.x ? 1 : -1));
-            int differenceY = (int) ((/*? if > 1.21.8 {*/event.y()/*?} else {*//*e*//*?}*/ - this.initialY) * (realAnchor.y < boundingPoint.y ? 1 : -1));
+            int differenceX = (int) ((event.x() - this.initialX) * (realAnchor.x < boundingPoint.x ? 1 : -1));
+            int differenceY = (int) ((event.y() - this.initialY) * (realAnchor.y < boundingPoint.y ? 1 : -1));
 
             slideValue = (int)(100f * ((float)(differenceX + differenceY)/(float)50));
             this.element.setScale(initialScale + slideValue/280f);
         }
-        return super.mouseDragged(/*? if > 1.21.8 {*/event, mouseX, mouseY/*?} else {*//*d, e, i, f, g*//*?}*/);
+        return super.mouseDragged(event, mouseX, mouseY);
     }
 
     @Override
-    public boolean mouseReleased(/*? if > 1.21.8 {*/MouseButtonEvent event/*?} else {*//*double d, double e, int i*//*?}*/) {
+    public boolean mouseReleased(MouseButtonEvent event) {
         this.isUserDragging = false;
-        return super.mouseReleased(/*? if > 1.21.8 {*/event/*?} else {*//*d, e, i*//*?}*/);
+        return super.mouseReleased(event);
     }
 
 }

--- a/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationScaleWidget.java
+++ b/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationScaleWidget.java
@@ -56,8 +56,8 @@ public class CustomizationScaleWidget extends Button implements MC {
         if(isUserDragging){
             Vector2f realAnchor = this.element.getCurrentAnchorPoint();
             Vector2f boundingPoint = this.element.getCurrentBoundingPoint();
-            int differenceX = (int) ((/*? if > 1.21.8 {*/mouseX/*?} else {*//*d*//*?}*/ - this.initialX) * (realAnchor.x < boundingPoint.x ? 1 : -1));
-            int differenceY = (int) ((/*? if > 1.21.8 {*/mouseY/*?} else {*//*e*//*?}*/ - this.initialY) * (realAnchor.y < boundingPoint.y ? 1 : -1));
+            int differenceX = (int) ((/*? if > 1.21.8 {*/event.x()/*?} else {*//*d*//*?}*/ - this.initialX) * (realAnchor.x < boundingPoint.x ? 1 : -1));
+            int differenceY = (int) ((/*? if > 1.21.8 {*/event.y()/*?} else {*//*e*//*?}*/ - this.initialY) * (realAnchor.y < boundingPoint.y ? 1 : -1));
 
             slideValue = (int)(100f * ((float)(differenceX + differenceY)/(float)50));
             this.element.setScale(initialScale + slideValue/280f);

--- a/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationScreen.java
+++ b/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationScreen.java
@@ -95,42 +95,42 @@ public class CustomizationScreen extends Screen implements uk.co.hexeption.apec.
     }
 
     @Override
-    public boolean mouseReleased(/*? if > 1.21.8 {*/MouseButtonEvent event/*?} else {*//*double d, double e, int i*//*?}*/) {
+    public boolean mouseReleased(MouseButtonEvent event) {
 
         refreshSnapPoints();
         saveDeltas();
-        return super.mouseReleased(/*? if > 1.21.8 {*/event/*?} else {*//*d, e, i*//*?}*/);
+        return super.mouseReleased(event);
     }
 
     @Override
-    public boolean mouseClicked(/*? if > 1.21.8 {*/MouseButtonEvent event, boolean isDoubleClick/*?} else {*//*double d, double e, int i*//*?}*/) {
+    public boolean mouseClicked(MouseButtonEvent event, boolean isDoubleClick) {
 
         refreshSnapPoints();
 
-        if (/*? if > 1.21.8 {*/event.button()/*?} else {*//*i*//*?}*/ == 0) {
+        if (event.button() == 0) {
             this.children().forEach(guiEventListener -> {
-                if (guiEventListener.mouseClicked(/*? if > 1.21.8 {*/event, isDoubleClick/*?} else {*//*d, e, i*//*?}*/) && guiEventListener instanceof CustomizationWidget)
-                    ((CustomizationWidget) guiEventListener).userStartedDragging(/*? if > 1.21.8 {*/event.x(), event.y()/*?} else {*//*d, e*//*?}*/);
+                if (guiEventListener.mouseClicked(event, isDoubleClick) && guiEventListener instanceof CustomizationWidget)
+                    ((CustomizationWidget) guiEventListener).userStartedDragging(event.x(), event.y());
             });
             this.children().forEach(guiEventListener -> {
-                if (guiEventListener.mouseClicked(/*? if > 1.21.8 {*/event, isDoubleClick/*?} else {*//*d, e, i*//*?}*/) && guiEventListener instanceof CustomizationScaleWidget)
-                    ((CustomizationScaleWidget) guiEventListener).userStartedDragging(/*? if > 1.21.8 {*/event.x(), event.y()/*?} else {*//*d, e*//*?}*/);
+                if (guiEventListener.mouseClicked(event, isDoubleClick) && guiEventListener instanceof CustomizationScaleWidget)
+                    ((CustomizationScaleWidget) guiEventListener).userStartedDragging(event.x(), event.y());
             });
         }
 
-        if (/*? if > 1.21.8 {*/event.button()/*?} else {*//*i*//*?}*/ == 1) {
+        if (event.button() == 1) {
             this.children().forEach(guiEventListener -> {
-                if (guiEventListener.mouseClicked(/*? if > 1.21.8 {*/event, isDoubleClick/*?} else {*//*d, e, i*//*?}*/) && guiEventListener instanceof CustomizationWidget)
+                if (guiEventListener.mouseClicked(event, isDoubleClick) && guiEventListener instanceof CustomizationWidget)
                     ((CustomizationWidget) guiEventListener).reset();
             });
             this.children().forEach(guiEventListener -> {
-                if (guiEventListener.mouseClicked(/*? if > 1.21.8 {*/event, isDoubleClick/*?} else {*//*d, e, i*//*?}*/) && guiEventListener instanceof CustomizationScaleWidget)
+                if (guiEventListener.mouseClicked(event, isDoubleClick) && guiEventListener instanceof CustomizationScaleWidget)
                     ((CustomizationScaleWidget) guiEventListener).resetScale();
             });
 
         }
 
-        return super.mouseClicked(/*? if > 1.21.8 {*/event, isDoubleClick/*?} else {*//*d, e, i*//*?}*/);
+        return super.mouseClicked(event, isDoubleClick);
     }
 
     private void saveDeltas() {

--- a/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationWidget.java
+++ b/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationWidget.java
@@ -101,7 +101,7 @@ public class CustomizationWidget extends Button implements MC {
     }
 
     @Override
-    public boolean mouseDragged(/*? if > 1.21.8 {*/MouseButtonEvent event, double mouseX, double mouseY/*?} else {*//*double d, double e, int i, double f, double g*//*?}*/) {
+    public boolean mouseDragged(MouseButtonEvent event, double mouseX, double mouseY) {
         if (isUserDragging) {
             Vector2f anchor;
             anchor = this.element.getAnchorPointPosition();
@@ -109,18 +109,18 @@ public class CustomizationWidget extends Button implements MC {
             boolean isSnappedToPositionX = false;
             boolean isSnappedToPositionY = false;
 
-            SnapData SnapResult = IsSnapped(/*? if > 1.21.8 {*/event.x(), event.y()/*?} else {*//*d, e*//*?}*/, anchor);
+            SnapData SnapResult = IsSnapped(event.x(), event.y(), anchor);
 
             isSnappedToPositionX = SnapResult.xSnap;
             isSnappedToPositionY = SnapResult.ySnap;
 
             Vector2f Result = new Vector2f(
-                    isSnappedToPositionX ? SnapResult.vector.x + fineTuneOffset.x : (float) (/*? if > 1.21.8 {*/event.x()/*?} else {*//*d*//*?}*/ - anchor.x + fineTuneOffset.x + startingPos.x),
-                    (float) ((isSnappedToPositionY ? SnapResult.vector.y + fineTuneOffset.y : /*? if > 1.21.8 {*/event.y()/*?} else {*//*e*//*?}*/ - anchor.y + fineTuneOffset.y + startingPos.y) * (lockY ? 0 : 1))
+                    isSnappedToPositionX ? SnapResult.vector.x + fineTuneOffset.x : (float) (event.x() - anchor.x + fineTuneOffset.x + startingPos.x),
+                    (float) ((isSnappedToPositionY ? SnapResult.vector.y + fineTuneOffset.y : event.y() - anchor.y + fineTuneOffset.y + startingPos.y) * (lockY ? 0 : 1))
             );
             this.element.setDeltaPosition(Result);
         }
-        return super.mouseDragged(/*? if > 1.21.8 {*/event, mouseX, mouseY/*?} else {*//*d, e, i, f, g*//*?}*/);
+        return super.mouseDragged(event, mouseX, mouseY);
     }
 
     private SnapData IsSnapped(double mouseX, double mouseY, Vector2f anchor) {
@@ -146,9 +146,9 @@ public class CustomizationWidget extends Button implements MC {
     }
 
     @Override
-    public boolean mouseReleased(/*? if > 1.21.8 {*/MouseButtonEvent event/*?} else {*//*double d, double e, int i*//*?}*/) {
+    public boolean mouseReleased(MouseButtonEvent event) {
         this.isUserDragging = false;
-        return super.mouseReleased(/*? if > 1.21.8 {*/event/*?} else {*//*d, e, i*//*?}*/);
+        return super.mouseReleased(event);
     }
 
     public void reset() {

--- a/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationWidget.java
+++ b/src/main/java/uk/co/hexeption/apec/hud/customization/CustomizationWidget.java
@@ -151,6 +151,15 @@ public class CustomizationWidget extends Button implements MC {
         return super.mouseReleased(event);
     }
 
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
+        if (subElementIndex == -1 && this.element.isScalable()) {
+            float mult = .05f * (mc.hasControlDown() ? .1f : 1f) *  (mc.hasShiftDown() ? 10f : 1f);
+            this.element.setScale(this.element.getScale() + (float) scrollY * mult);
+        }
+        return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
+    }
+
     public void reset() {
         this.element.setDeltaPosition(new Vector2f(0, 0));
     }

--- a/src/main/java/uk/co/hexeption/apec/mixins/MixinGui.java
+++ b/src/main/java/uk/co/hexeption/apec/mixins/MixinGui.java
@@ -185,11 +185,15 @@ public abstract class MixinGui implements MC {
     @ModifyVariable(method = "extractSelectedItemName", at = @At(value = "STORE"), ordinal = 1)
     private int modifyXPosition(int original, GuiGraphicsExtractor guiGraphics) {
 
-        var toolTipText = (uk.co.hexeption.apec.hud.elements.ToolTipText) Apec.apecMenu.getGuiComponent(ElementType.TOOL_TIP_TEXT);
-
         if (!Apec.SKYBLOCK_INFO.isOnSkyblock()) {
             return original;
         }
+
+        if (!Apec.apecMenu.shouldShowHUD()) {
+            return original;
+        }
+
+        var toolTipText = (uk.co.hexeption.apec.hud.elements.ToolTipText) Apec.apecMenu.getGuiComponent(ElementType.TOOL_TIP_TEXT);
 
         if(Apec.INSTANCE.settingsManager.getSettingState(SettingID.ITEM_HIGHLIGHT_TEXT)){
             int textWidth = guiGraphics.guiWidth() - 2 * original;
@@ -202,11 +206,15 @@ public abstract class MixinGui implements MC {
     @ModifyVariable(method = "extractSelectedItemName", at = @At(value = "STORE"), ordinal = 2)
     private int modifyYPosition(int original, GuiGraphicsExtractor guiGraphics) {
 
-        var toolTipText = (uk.co.hexeption.apec.hud.elements.ToolTipText) Apec.apecMenu.getGuiComponent(ElementType.TOOL_TIP_TEXT);
-
         if (!Apec.SKYBLOCK_INFO.isOnSkyblock()) {
             return original;
         }
+
+        if (!Apec.apecMenu.shouldShowHUD()) {
+            return original;
+        }
+
+        var toolTipText = (uk.co.hexeption.apec.hud.elements.ToolTipText) Apec.apecMenu.getGuiComponent(ElementType.TOOL_TIP_TEXT);
 
         return toolTipText.getYOffset(guiGraphics);
     }

--- a/src/main/java/uk/co/hexeption/apec/mixins/container/MixinAbstractContainerScreen.java
+++ b/src/main/java/uk/co/hexeption/apec/mixins/container/MixinAbstractContainerScreen.java
@@ -156,9 +156,9 @@ public abstract class MixinAbstractContainerScreen extends Screen implements MC,
         ContainerGuiOverlay overlay = apec$getOverlay();
         if (overlay == null) return;
         // Allow ESC to close container
-        if (/*? if > 1.21.8 {*/event.key()/*?} else {*//*keyCode*//*?}*/ == 256 /* GLFW.GLFW_KEY_ESCAPE */) return;
+        if (event.key() == 256 /* GLFW.GLFW_KEY_ESCAPE */) return;
         List<Slot> slots = this.menu != null ? this.menu.slots : java.util.List.of();
-        boolean handled = overlay.keyPressed(this.menu, slots, /*? if > 1.21.8 {*/event.key(), event.scancode(), event.modifiers()/*?} else {*//*keyCode, scanCode, modifiers*//*?}*/);
+        boolean handled = overlay.keyPressed(this.menu, slots, event.key(), event.scancode(), event.modifiers());
         if (handled) {
             cir.setReturnValue(true);
             cir.cancel();


### PR DESCRIPTION
Fixed more stuff.
---

### Scaling
   - **_Fix:_** Fixed the scaling of elements bugging out when trying to use the mouse.
   - Added the ability to scale elements using the scroll whell (with multipliers when using shift [10x] and ctrl [.1x]) as an alternative to dragging the mouse. [^1]
### Tooltip
   - _**Fix:**_ actually made it so when Apec is toggled off the tooltip goes back to the original. (bug from #11)
### Misc.
   - Removed some more stonecutter switches missed in #12 
  

[^1]: Could make a setting for toggling this but I feel like it's good enough QOL to not need one.